### PR TITLE
Docs have a broken url to the schema

### DIFF
--- a/config-docs.MD
+++ b/config-docs.MD
@@ -2,7 +2,7 @@
 
 ## <a name="overview">Overview</a>
 
-Libris uses a JSON configuration file to allow it to accept a variety of inputs and collate them together into a single PDF document. Configuration files are validated using [JSON Schema](https://json-schema.org/) and must match the schema file found at https://github.com/lazy-scrivener-games/libris/json-schemas/config-schema.json.
+Libris uses a JSON configuration file to allow it to accept a variety of inputs and collate them together into a single PDF document. Configuration files are validated using [JSON Schema](https://json-schema.org/) and must match the schema file found at [libris/json-schemas/config-schema.json](https://raw.githubusercontent.com/lazy-scrivener-games/libris/main/libris/json-schemas/config-schema.json).
 
 Styles are defined and attached to strings so that they can be easily referenced. This is because a style might encompass multiple CSS stylesheets, and/or might use the templating option we call "decorators."
 


### PR DESCRIPTION
Hmm, this alone won't allow a user to point to the schema via url, since all of the schemas have the same url structure which is wrong. (It's missing the inner libris folder and the `tree/main` or hitting the raw url).

Not sure what the preferred method to fix this is. I'd ideally like to not have to copy all of these files in. In theory they should have been packaged with libris, right? Can I use them without having to dig up what the path they got installed into is?